### PR TITLE
Updating the saveFiles.js to check if account is private

### DIFF
--- a/lib/util/saveFiles.js
+++ b/lib/util/saveFiles.js
@@ -158,9 +158,12 @@ var fetchAndSave = function fetchAndSave(_ref5, cb) {
 
   var fetchMedia = function fetchMedia(err, medias, pagination, remaining) {
     debugApi('API calls left ' + remaining);
-    debugApi('Has next page ' + !!pagination.next);
 
     if (err) {
+      console.log(err.error_type);
+      if (err.error_type === 'APINotAllowedError') {
+        debugApi('Its possible the user\'s account you are trying to download is private');
+      }
       debugApi('API error ' + err);
     } else if (medias && medias.length) {
       COUNT += medias.length;
@@ -181,7 +184,10 @@ var fetchAndSave = function fetchAndSave(_ref5, cb) {
       cb();
     }
 
-    pagination.next && pagination.next(fetchMedia);
+    if (pagination) {
+      debugApi('Has next page ' + !!pagination.next);
+      return pagination.next && pagination.next(fetchMedia);
+    }
   };
 
   return fetchMedia;

--- a/lib/util/saveFiles.js
+++ b/lib/util/saveFiles.js
@@ -160,7 +160,6 @@ var fetchAndSave = function fetchAndSave(_ref5, cb) {
     debugApi('API calls left ' + remaining);
 
     if (err) {
-      console.log(err.error_type);
       if (err.error_type === 'APINotAllowedError') {
         debugApi('Its possible the user\'s account you are trying to download is private');
       }
@@ -169,7 +168,6 @@ var fetchAndSave = function fetchAndSave(_ref5, cb) {
       COUNT += medias.length;
       debugApi('Fetched media ' + medias.length);
       debugApi('Fetched total ' + COUNT);
-
       medias.forEach(function (media) {
         jsonQueue.push(media);
         (0, _lodashCollectionEach2['default'])(media.images, function (img) {
@@ -186,7 +184,7 @@ var fetchAndSave = function fetchAndSave(_ref5, cb) {
 
     if (pagination) {
       debugApi('Has next page ' + !!pagination.next);
-      return pagination.next && pagination.next(fetchMedia);
+      pagination.next && pagination.next(fetchMedia);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instagram-download",
   "description": "Download all the Instagram JSON data and media for a user.",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "author": "Luke Karrys <luke@lukekarrys.com>",
   "bin": {
     "instagram-download": "./lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instagram-download",
   "description": "Download all the Instagram JSON data and media for a user.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "Luke Karrys <luke@lukekarrys.com>",
   "bin": {
     "instagram-download": "./lib/cli.js"

--- a/src/util/saveFiles.js
+++ b/src/util/saveFiles.js
@@ -101,7 +101,6 @@ export const fetchAndSave = ({jsonQueue, mediaQueue}, cb) => {
     debugApi(`API calls left ${remaining}`)
 
     if (err) {
-      console.log(err.error_type)
       if (err.error_type === 'APINotAllowedError') {
         debugApi(`Its possible the user's account you are trying to download is private`)
       }

--- a/src/util/saveFiles.js
+++ b/src/util/saveFiles.js
@@ -99,15 +99,17 @@ export const fetchAndSave = ({jsonQueue, mediaQueue}, cb) => {
 
   const fetchMedia = (err, medias, pagination, remaining) => {
     debugApi(`API calls left ${remaining}`)
-    debugApi(`Has next page ${!!pagination.next}`)
 
     if (err) {
+      console.log(err.error_type)
+      if (err.error_type === 'APINotAllowedError') {
+        debugApi(`Its possible the user's account you are trying to download is private`)
+      }
       debugApi(`API error ${err}`)
     } else if (medias && medias.length) {
       COUNT += medias.length
       debugApi(`Fetched media ${medias.length}`)
       debugApi(`Fetched total ${COUNT}`)
-
       medias.forEach((media) => {
         jsonQueue.push(media)
         each(media.images, (img) => mediaQueue.push(img.url))
@@ -118,7 +120,10 @@ export const fetchAndSave = ({jsonQueue, mediaQueue}, cb) => {
       cb()
     }
 
-    pagination.next && pagination.next(fetchMedia)
+    if (pagination) {
+      debugApi(`Has next page ${!!pagination.next}`)
+      pagination.next && pagination.next(fetchMedia)
+    }
   }
 
   return fetchMedia


### PR DESCRIPTION
I was getting an error downloading my profile because it was private (DOH!), which might not be obvious to others projects implementing this library (https://github.com/rtorr/universal-static-instagram for example). 

Running `DEBUG=instagram-download:* babel-node server/data/fetch.js` in https://github.com/rtorr/universal-static-instagram will now produce 

``````
 instagram-download:options OPT dir /Users/rtorr/rtorr/universal-static-instagram/_cache +0ms
  instagram-download:options OPT client 21de5de8375348309375aef95239de57 +3ms
  instagram-download:options OPT secret 15f686934ae14d32b6c5f5f6a940c99f +2ms
  instagram-download:options OPT user 919141 +0ms
  instagram-download:options OPT domain i.rtorr.com +0ms
  instagram-download:options OPT _  +0ms
  instagram-download:download User dir /Users/rtorr/rtorr/universal-static-instagram/_cache/919141 +2ms
  instagram-download:download Json dir /Users/rtorr/rtorr/universal-static-instagram/_cache/919141/json +1ms
  instagram-download:download Media dir /Users/rtorr/rtorr/universal-static-instagram/_cache/919141/media +0ms
  instagram-download:options OPT dir /Users/rtorr/rtorr/universal-static-instagram/_cache +31ms
  instagram-download:options OPT user 919141 +0ms
  instagram-download:read Reading directory /Users/rtorr/rtorr/universal-static-instagram/_cache/919141/json +1ms
  instagram-download:download Fetching since 1071130014453381884_919141 2015-09-10T18:11:09.000Z +149ms
  instagram-download:api API calls left undefined +280ms
APINotAllowedError
  instagram-download:api Its possible the user's account you are trying to download is private +0ms
  instagram-download:api API error Error: APINotAllowedError: you cannot view this resource +1ms```

Which can be helpful. 
``````
